### PR TITLE
fix(dfu): transfer canceled error on page erase

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -198,7 +198,9 @@ fn reboot_cmd(
 fn show_uf2(file: &PathBuf) -> Result<(), CliError> {
     let data = fs::read(file)?;
     if !is_uf2_block(&data) {
-        return Err(CliError::UF2(UF2DecodeError));
+        return Err(CliError::UF2(UF2DecodeError::new(
+            "invalid first block".to_string(),
+        )));
     }
     let block = UF2BlockData::decode(&data[0..UF2_BLOCK_SIZE])?;
     println!(

--- a/cli/src/write.rs
+++ b/cli/src/write.rs
@@ -58,7 +58,6 @@ fn download_range(
 
     // erase first
     let erase_pages = intf.get_erase_pages(start_address, end_address);
-    let erase_start = erase_pages.first().unwrap_or(&0u32).to_owned();
     let pages = erase_pages.len();
 
     for (page, page_addr) in erase_pages.into_iter().enumerate() {
@@ -66,7 +65,7 @@ fn download_range(
             "\r  Erasing page {:2} of {:2} @ 0x{:08x}",
             page + 1,
             pages,
-            erase_start
+            page_addr,
         );
         let _ = io::stdout().flush();
         if let Err(err) = connection.dfuse_page_erase(page_addr) {

--- a/dfu/src/lib.rs
+++ b/dfu/src/lib.rs
@@ -30,7 +30,7 @@
 //! [`nusb`]: https://docs.rs/nusb
 //! [EdgeTX]: https://github.com/EdgeTX/edgetx
 
-pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_millis(500u64);
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_millis(5000u64);
 pub(crate) const DEFAULT_TRANSFER_SIZE: u16 = 1024 * 2;
 
 mod connection;


### PR DESCRIPTION
When a DFU operation takes more time to complete than the USB request timeout, the request must be retried a few times.
This is especially visible on page erase which might take seconds to complete.