### PR TITLE
fix: add debug library for Windows linked to msvcrtd

### DIFF
--- a/.cargo/windbg-config.toml
+++ b/.cargo/windbg-config.toml
@@ -1,0 +1,3 @@
+[env]
+CFLAGS = "/MDd"
+CXXFLAGS = "/MDd"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,12 +49,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build
+      - name: Release Build
         uses: houseabsolute/actions-rust-cross@v1
         with:
           command: ${{ matrix.platform.command }}
           target: ${{ matrix.platform.target }}
           args: "--locked --all --release"
+
+      - name: Debug Build
+        uses: houseabsolute/actions-rust-cross@v1
+        if: startsWith(matrix.platform.os-name, 'Windows')
+        with:
+          command: ${{ matrix.platform.command }}
+          target: ${{ matrix.platform.target }}
+          args: "--config .cargo/windbg-config.toml --locked --all"
 
       - name: Store command line tool
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ This creates a distribution archive containing:
 - C++ header files
 - CMake configuration files
 
+On Windows, if a debug build is necessary, the library can be built with:
+```bash
+# Build Rust library
+cargo build --all
+
+# Generate distribution package
+./package.sh
+```
+
 ### Running Tests
 
 ```bash

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,20 @@
+use std::env;
+
 fn main() {
     cxx_build::bridge("src/lib.rs")
         .cpp(true)
         .std("c++14")
         .compile("rs_dfu");
+
+    if env::var("TARGET").is_ok_and(|s| s.contains("windows-msvc")) {
+        // MSVC compiler suite
+        if env::var("CFLAGS").is_ok_and(|s| s.contains("/MDd")) {
+            // debug runtime flag is set
+
+            // Don't link the default CRT
+            println!("cargo::rustc-link-arg=/nodefaultlib:msvcrt");
+            // Link the debug CRT instead
+            println!("cargo::rustc-link-arg=/defaultlib:msvcrtd");
+        }
+    }
 }

--- a/cmake/rs_dfu-config.cmake
+++ b/cmake/rs_dfu-config.cmake
@@ -7,6 +7,7 @@ if(WIN32)
     set(_rs_dfu_lib_prefix "")
     set(_rs_dfu_shared_ext "dll")
     set(_rs_dfu_static_ext "lib")
+    set(_rs_dfu_debug_suffix "d")
     set(_rs_dfu_system_libs ws2_32 userenv winusb ntdll cfgmgr32)
 elseif(APPLE)
     set(_rs_dfu_lib_prefix "lib")
@@ -26,7 +27,13 @@ set(RS_DFU_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
 set(RS_DFU_INCLUDE_DIR "${RS_DFU_DIR}/include")
 set(RS_DFU_LIB_DIR "${RS_DFU_DIR}/lib")
 
-set(_rs_dfu_static_lib "${RS_DFU_LIB_DIR}/${_rs_dfu_lib_prefix}rs_dfu.${_rs_dfu_static_ext}")
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    set(_rs_dfu_libname "${_rs_dfu_lib_prefix}rs_dfu")
+else()
+    set(_rs_dfu_libname "${_rs_dfu_lib_prefix}rs_dfu${_rs_dfu_debug_suffix}")
+endif()
+
+set(_rs_dfu_static_lib "${RS_DFU_LIB_DIR}/${_rs_dfu_libname}.${_rs_dfu_static_ext}")
 
 # Create imported target
 if(EXISTS "${_rs_dfu_static_lib}" AND NOT TARGET rs_dfu::static)

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -47,8 +47,8 @@ target_include_directories(cpp-example PRIVATE
   ${CARGO_CXX_TARGET_DIR}/src
 )
 
-target_link_libraries(cpp-example fmt::fmt)
-target_link_libraries(cpp-example ${RS_DFU_LIB})
+target_link_libraries(cpp-example PRIVATE fmt::fmt)
+target_link_libraries(cpp-example PRIVATE ${RS_DFU_LIB})
 
 if(APPLE)
   target_link_libraries(cpp-example PRIVATE

--- a/package.sh
+++ b/package.sh
@@ -24,22 +24,21 @@ esac
 LIB_NAME="rs_dfu"
 TARGET_DIR=${2:-"target"}
 
-if [ -d "${TARGET_DIR}/release" ]; then
-    PROFILE_DIR=${3:-"release"}
-elif [ -d "${TARGET_DIR}/debug" ]; then
-    PROFILE_DIR=${3:-"debug"}
-    TARGET="${TARGET}-debug"
-fi
-
 # Create distribution structure
 rm -rf dist
 mkdir -p dist/cmake dist/include dist/lib
 
 # Copy libraries
-STATIC_LIB="${TARGET_DIR}/${PROFILE_DIR}/${LIB_PREFIX}${LIB_NAME}.${STATIC_EXT}"
-if [ -f "$STATIC_LIB" ]; then
-    cp "$STATIC_LIB" "dist/lib/"
-    echo "Copied: $STATIC_LIB"
+RELEASE_LIB="${TARGET_DIR}/release/${LIB_PREFIX}${LIB_NAME}.${STATIC_EXT}"
+if [ -f "$RELEASE_LIB" ]; then
+    cp "$RELEASE_LIB" "dist/lib/"
+    echo "Copied: $RELEASE_LIB"
+fi
+
+DEBUG_LIB="${TARGET_DIR}/debug/${LIB_PREFIX}${LIB_NAME}.${STATIC_EXT}"
+if [ -f "$DEBUG_LIB" ]; then
+    cp "$DEBUG_LIB" "dist/lib/${LIB_PREFIX}${LIB_NAME}d.${STATIC_EXT}"
+    echo "Copied: $DEBUG_LIB -> ${LIB_PREFIX}${LIB_NAME}d.${STATIC_EXT}"
 fi
 
 # Copy headers


### PR DESCRIPTION
This MR adds support for linking the library against `msvcrtd` instead of `msvcrt` and adds debug switches (`/MDd`) to the Windows debug profile.

For Windows specifically, the debug version of the static library is added to the package to allow C++ programs to be built with Debug on Windows.

The changes in this MR are based on:
- https://github.com/dtolnay/cxx/issues/880#issuecomment-2521375384
- https://github.com/rust-lang/rust/issues/39016#issuecomment-2521395154