### PR TITLE
feat(ci): build macOS universal binaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,8 +85,59 @@ jobs:
           name: library-${{ matrix.platform.os-name }}
           path: rs_dfu-*.tar.gz
 
-  release:
+  macos-universal:
+    name: Build (macOS-universal)
     needs: build
+    runs-on: macos-latest
+    steps:
+      - name: Download macOS CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: rdfu-macOS-*
+          path: artifacts
+
+      - name: Download macOS library artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: library-macOS-*
+          path: artifacts
+
+      - name: Create universal CLI binary
+        run: |
+          lipo -create \
+            artifacts/rdfu-macOS-x86_64/rdfu \
+            artifacts/rdfu-macOS-arm64/rdfu \
+            -output rdfu
+          lipo -info rdfu
+
+      - name: Store universal CLI tool
+        uses: actions/upload-artifact@v4
+        with:
+          name: rdfu-macOS-universal
+          path: rdfu
+
+      - name: Create universal library
+        run: |
+          mkdir -p x86_64 arm64
+          tar -xzf artifacts/library-macOS-x86_64/rs_dfu-x86_64-apple-darwin.tar.gz -C x86_64
+          tar -xzf artifacts/library-macOS-arm64/rs_dfu-aarch64-apple-darwin.tar.gz -C arm64
+
+          mkdir -p dist/cmake dist/include dist/lib
+          lipo -create x86_64/lib/librs_dfu.a arm64/lib/librs_dfu.a -output dist/lib/librs_dfu.a
+          lipo -info dist/lib/librs_dfu.a
+          cp arm64/include/* dist/include/
+          cp arm64/cmake/* dist/cmake/
+
+          tar -czf rs_dfu-universal-apple-darwin.tar.gz --strip-component 1 dist/
+
+      - name: Store universal library
+        uses: actions/upload-artifact@v4
+        with:
+          name: library-macOS-universal
+          path: rs_dfu-universal-apple-darwin.tar.gz
+
+  release:
+    needs: [build, macos-universal]
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
     steps:
@@ -98,7 +149,7 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir release-assets
-          
+
           # CLI tools with simplified names
           for d in artifacts/rdfu-*; do
             name=$(basename "$d")
@@ -108,7 +159,7 @@ jobs:
               cp "$d/rdfu" "release-assets/${name}"
             fi
           done
-          
+
           # Libraries with original names (preserving the full Rust target triple)
           find artifacts/library-* -name "*.tar.gz" -exec cp {} release-assets/ \;
 


### PR DESCRIPTION
## Summary
- Add a `macos-universal` CI job that combines the x86_64 and arm64 macOS builds into universal binaries using `lipo`
- Produces universal versions of both the CLI tool (`rdfu`) and the static library (`librs_dfu.a`)
- Universal artifacts are included in release assets alongside per-arch builds

## Test plan
- [x] Verify the `macos-universal` job runs successfully after both macOS builds complete
- [ ] Confirm `lipo -info` output shows both `x86_64` and `arm64` architectures
- [ ] Verify universal artifacts appear in release assets when a tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)