### PR TITLE
Don't bail on first failed DFU interface probe

### DIFF
--- a/dfu/src/device.rs
+++ b/dfu/src/device.rs
@@ -176,8 +176,28 @@ pub fn find_dfu_devices(
         .collect();
     let mut dfu_devices = Vec::with_capacity(devices.len());
     for device in devices {
-        if let Some(dfu_device) = DfuDevice::from_device_info(device)? {
-            dfu_devices.push(dfu_device);
+        match DfuDevice::from_device_info(device.clone()) {
+            Ok(Some(dfu_device)) => dfu_devices.push(dfu_device),
+            Ok(None) => {
+                log::debug!(
+                    "No DFU interface found for {vid:04X}:{pid:04X}{serial}",
+                    vid = device.vendor_id(),
+                    pid = device.product_id(),
+                    serial = device
+                        .serial_number()
+                        .map(|s| format!(" (S/N: {s})"))
+                        .unwrap_or_default()
+                )
+            }
+            Err(e) => log::warn!(
+                "Unable to query {vid:04X}:{pid:04X}{serial} for DFU interfaces ({e})",
+                vid = device.vendor_id(),
+                pid = device.product_id(),
+                serial = device
+                    .serial_number()
+                    .map(|s| format!(" (S/N: {s})"))
+                    .unwrap_or_default()
+            ),
         }
     }
     Ok(dfu_devices)


### PR DESCRIPTION
Howdy!

Just wanted to throw in a small fix to this crate, since I've been deferring to it since it's nice and portable (and shows me a real-world example of `nusb`!).

I have a DFU device with the correct `udev` rules for me to access it without root, but when `rdfu` is iterating through all the USB devices, it fails on an __unrelated__ USB device and bails on the entire search.

I don't know if you'd prefer to use the `log` crate to avoid having a possibly-intrusive/unrelated `println!()` each time it fails, so I just deferred to `log`. Lemme know if you'd prefer something else.

Before:

```
$ RUST_LOG=debug cargo run -- list
   Compiling dfu v0.7.1 (/home/.../rs-dfu/dfu)
   Compiling rdfu v0.7.1 (/home/.../rs-dfu/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.87s
     Running `target/debug/rdfu list`
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.5"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.1/3-3.2.1.1"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2/2-1.2.2"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.1"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.5"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.3"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-9"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.1"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-7"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-10"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2/2-1.2.1"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.4"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.2"
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::device] Opened device fd=3 with id 0
# ... truncated for brevity ...
[2026-06-10T18:04:09Z DEBUG nusb::platform::linux_usbfs::device] Closing device 0
[2026-06-10T18:04:09Z DEBUG nusb::error] failed to open device (errno 13)
Error: DFU error: USB error: failed to open device (errno 13)
```

After:

```
$ RUST_LOG=debug cargo run -- list
   Compiling dfu v0.7.1 (/home/.../rs-dfu/dfu)
   Compiling rdfu v0.7.1 (/home/.../rs-dfu/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s
     Running `target/debug/rdfu list`
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.5"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.1/3-3.2.1.1"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2/2-1.2.2"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.1"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.5"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.3"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-9"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.1"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-7"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-10"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:0d.0/usb2/2-1/2-1.2/2-1.2.1"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.4"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::enumeration] Probing device "/sys/devices/pci0000:00/0000:00:14.0/usb3/3-3/3-3.2/3-3.2.2"
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::device] Opened device fd=3 with id 0
# ... truncated for brevity ...
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::device] Closing device 0
[2026-06-10T18:05:30Z DEBUG nusb::error] failed to open device (errno 13)
[2026-06-10T18:05:30Z WARN  dfu::device] Unable to query 30C9:00F3 (S/N: 0001) for DFU interfaces (USB error: failed to open device (errno 13))
# ^ not my desired device ^
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::device] Opened device fd=3 with id 0
# ... truncated for brevity ...
[2026-06-10T18:05:30Z DEBUG nusb::platform::linux_usbfs::device] Closing device 0
Bus 003 Device 063: ID 0483:df11 (ver=2.00, dfuse=true) # <- my actual desired device
  Internal Flash (intf=0, alt=0):
    0x08000000 64 pages of    2K bytes (rwe)
  Option Bytes (intf=0, alt=1):
    0x1FFF7800  1 pages of   40  bytes (rw)
  OTP Memory (intf=0, alt=2):
    0x1FFF7000  1 pages of    1K bytes (rw)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced DFU device discovery to gracefully handle errors on individual devices without halting the entire scanning process. Improved diagnostic logging to help identify problematic devices using vendor and product information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->